### PR TITLE
Fix error handling in users controller and service

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -8,15 +8,11 @@ module.exports = {
   post: catchAsync(async (req, res, next) => {
     try {
       const response = await createUser(req.body)
-      if (!response) {
-        res.send({ code: 409, msg: 'Email already in use, try another email address' })
-      } else {
-        endpointResponse({
-          res,
-          message: 'User registered successfully',
-          body: response,
-        })
-      }
+      endpointResponse({
+        res,
+        message: 'User registered successfully',
+        body: response,
+      })
     } catch (error) {
       const httpError = createHttpError(
         error.statusCode,

--- a/services/users.js
+++ b/services/users.js
@@ -7,7 +7,7 @@ exports.createUser = async (data) => {
     const emailExists = await User.findOne({ where: { email: data.email } })
 
     if (emailExists) {
-      throw new ErrorObject('Email already exist', 404)
+      throw new ErrorObject('Email already exist', 409)
     }
 
     const encryptedPassword = await bcrypt.hash(data.password, 10)


### PR DESCRIPTION
Al momento de ingresar un mail existente en la base de datos había un doble manejo de error, en el controller de users y en el servicio de users. El del controller no se usaba, salía por el de servicios. Y este tenía un error en el código que entregaba, que era 404 en lugar de 409.

## Evidence:
![image](https://user-images.githubusercontent.com/79290983/192048046-1a6effb8-9d41-4260-a16a-255d1fc0cd58.png)


