### PR TITLE
[ENDPOINT] - OT287-62 - Enpoint /activities/:id for Activities Form Reusable to edit & create with CKeditor #39

### DIFF
--- a/controllers/activities.js
+++ b/controllers/activities.js
@@ -1,9 +1,25 @@
 const createHttpError = require('http-errors')
-const { editActivity, createActivity } = require('../services/activities')
+const { editActivity, createActivity, getActivityById } = require('../services/activities')
 const { endpointResponse } = require('../helpers/success')
 const { catchAsync } = require('../helpers/catchAsync')
 
 module.exports = {
+  getById: catchAsync(async (req, res, next) => {
+    try {
+      const response = await getActivityById(req.params.id)
+      endpointResponse({
+        res,
+        message: 'Activity retrieved successfully',
+        body: response,
+      })
+    } catch (error) {
+      const httpError = createHttpError(
+        error.statusCode,
+        `[Error retrieving activity] - [activity - GET]: ${error.message}`,
+      )
+      next(httpError)
+    }
+  }),
   put: catchAsync(async (req, res, next) => {
     try {
       const response = await editActivity(req.params.id, req.body)

--- a/routes/activities.js
+++ b/routes/activities.js
@@ -1,10 +1,11 @@
 const express = require('express')
-const { put, post } = require('../controllers/activities')
+const { getById, put, post } = require('../controllers/activities')
 const { activities } = require('../schemas/activities')
 const { validate } = require('../middlewares/validations')
 
 const router = express.Router()
 
+router.get('/:id', getById)
 router.put('/:id', put)
 router.post('/', validate(activities), post)
 

--- a/services/activities.js
+++ b/services/activities.js
@@ -1,6 +1,18 @@
 const { ErrorObject } = require('../helpers/error')
 const { Activity } = require('../database/models')
 
+exports.getActivityById = async (idNew) => {
+  try {
+    const getActivity = await Activity.findByPk(idNew)
+    if (!getActivity) {
+      throw new ErrorObject('No activity found', 404)
+    }
+    return getActivity
+  } catch (error) {
+    throw new ErrorObject(error.message, error.statusCode || 500)
+  }
+}
+
 exports.editActivity = async (id, data) => {
   try {
     const activity = await Activity.findByPk(id)


### PR DESCRIPTION
## Jira Ticket

- [OT287-62](https://alkemy-labs.atlassian.net/jira/software/c/projects/OT287/boards/381?modal=detail&selectedIssue=OT287-62)

## Description
As: Usuario administrador
Want: Crear o editar una actividad existente
To: Mantener el contenido actualizado

Criterios de aceptación: El mismo contendrá los campos Nombre (en el modelo activities es name) y Contenido (en el modelo activities es content). Para el contenido, utilizar la librería CKEditor. El objetivo es crear un formulario reutilizable para las acciones de edición como de creación de Actividades. Para esto, deberá poder comportarse de forma diferente según recibe una actividad o no.  En el caso de no recibir un objeto, significa que está realizando una acción de creación, por lo que deberá mostrar los campos vacíos y realizar una petición POST al endpoint de creación de Actividades (/Actividades). En el caso de recibir un objeto, completar el formulario con los campos del mismo y realizar una petición PATCH al endpoint de actualización (/activities/:id). Este formulario se mostrará en el backoffice tanto para la creación como edición

## Evidence:

![evidenciaGetActivityById](https://user-images.githubusercontent.com/96206226/193367017-b577543b-2027-4503-bc3c-607a7c3b54ed.PNG)
