### PR TITLE
fix: error handling users service

### DIFF
--- a/services/users.js
+++ b/services/users.js
@@ -33,6 +33,9 @@ exports.getUsers = async () => {
     const allUsers = await User.findAll({
       include: ['role'],
     })
+    if (!allUsers || allUsers.length === 0) {
+      throw new ErrorObject('Users not found', 404)
+    }
     return allUsers
   } catch (error) {
     throw new ErrorObject(error.message, error.statusCode || 500)


### PR DESCRIPTION
Se agregó lógica para poder manejar el error en caso de no encontrar usuarios en la base de datos.  El body de la respuesta estaba respondiendo con un array vacío.

![errohand](https://user-images.githubusercontent.com/85371377/193420133-3c43be23-d4b8-4742-a798-2fedd3c06b0e.png)
