### PR TITLE
Fix an if with wrong logic operator (was and instead of or)

### DIFF
--- a/services/users.js
+++ b/services/users.js
@@ -74,17 +74,15 @@ exports.updateUser = async (id, body) => {
       firstName, lastName, email, roleId,
     } = body
     const user = await User.findByPk(id)
-    if (!user && user.deleteAt) {
+    if (!user || user.deleteAt) {
       throw new ErrorObject('User not found', 404)
     } else {
-      await user.update(
-        {
-          firstName,
-          lastName,
-          email,
-          roleId,
-        },
-      )
+      await user.update({
+        firstName,
+        lastName,
+        email,
+        roleId,
+      })
       await user.save()
       return user
     }


### PR DESCRIPTION
Para detectar si el usuario era inexistente en el servicio de update tenía un AND entre las dos condiciones y por ende nunca se cumplía, y si el usuario era inexistente se iba por el catch. Lo cambié a OR para que funcione.


